### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Vercel
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MERN-FS/client/security/code-scanning/1](https://github.com/MERN-FS/client/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and deploys to Vercel (using secrets for authentication), it does not require any write permissions. The minimal required permission is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
